### PR TITLE
Set `max-width` instead of `width`

### DIFF
--- a/themes/hugo-book/assets/_markdown.scss
+++ b/themes/hugo-book/assets/_markdown.scss
@@ -59,7 +59,7 @@ $block-border-radius: 0.15rem;
   }
 
   img {
-    width: 90%;
+    max-width: 90%;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   }
 }


### PR DESCRIPTION
Setting `width` on small images caused them to become larger than they
should. Since the intent was to ensure that they do not grow over the
width of the parent container, `max-width` seems like the correct
choice.